### PR TITLE
Add support for Argent's ENS addresses

### DIFF
--- a/src/modals/TransferModal.js
+++ b/src/modals/TransferModal.js
@@ -415,7 +415,7 @@ class TransferModal extends React.Component {
     (async () => {
       let address = value;
       // Check ENS
-      if (value.toLowerCase().endsWith('.eth')) {
+      if (value.toLowerCase().match(/\.(eth|xyz)$/g)) {
         this.setState({
           addressLoading: true,
         });
@@ -694,7 +694,7 @@ class TransferModal extends React.Component {
                 loading={this.state.addressLoading}
                 disabled={this.state.addressLoading}
               />
-              {this.state.addressValue.toLowerCase().endsWith(".eth") &&
+              {this.state.addressValue.toLowerCase().match(/\.(eth|xyz)$/g) &&
                 !!this.state.toAddress && (
                   <div
                     style={{


### PR DESCRIPTION
Argent wallet's use ENS domain names that ends with `.xyz`, so
we should check for both `eth` and `xyz` suffixs in order to give
support for that users too.

**ENS Resolved:**
![Selección_999(037)](https://user-images.githubusercontent.com/442938/84475102-f6befd00-ac59-11ea-8609-17da48ef7505.png)

**Successful Sent:**
![Selección_999(038)](https://user-images.githubusercontent.com/442938/84475185-1524f880-ac5a-11ea-82f8-8fa84e5bba32.png)

**Successfully Received:**
![Selección_999(039)](https://user-images.githubusercontent.com/442938/84475234-2e2da980-ac5a-11ea-9a8b-3451d9949c5d.png)


Fixes #159 