### PR TITLE
Add HAL withdrawal notification integration

### DIFF
--- a/public/assets/i18n/translations/en.json
+++ b/public/assets/i18n/translations/en.json
@@ -31,6 +31,7 @@
     "WithdrawInstruction_Fee_2": " for each withdrawal.",
     "WithdrawInstructionNotification": "Your withdrawal request has been submitted to Ethereum. Please monitor your transaction, as you will not see the corresponding withdrawal record on Loopring Exchange before it is confirmed on-chain. Note: after you see your Ethereum transaction confirmed on-chain, it will be perfectly normal that it says 'processing' on the exchange, and that your withdrawal will not immediately be in your wallet: the relayer must prove the batch. Please be patient.",
     "WithdrawInstructionNotificationFailed": "Your withdrawal request failed. Please try again!",
+    "WithdrawHalNotification": "Get notified on withdrawal available in your wallet using HAL (you will be redirect there for activation)",
     "LogoutInstruct_1": "Logging out of the Loopring Exchange will clear your account key from this browser. You can log in again. You can always reset your account key with an Ethereum transaction, which means forgetting your account key will not make you lose any funds on Loopring.",
     "LogoutInstruct_2": "Are you sure you want to log out?",
     "AccountBeingRegisteredInstruct_1": "Your account is being created. We will wait for at least one confirmation for your Ethereum transaction. Please be patient.",

--- a/public/assets/i18n/translations/zh.json
+++ b/public/assets/i18n/translations/zh.json
@@ -135,6 +135,7 @@
     "WithdrawInstruction_Fee_2":"。",
     "WithdrawInstructionNotification": "您的提现请求已成功提交到以太坊。请注意观察该笔交易的状态，在它没有被确认前，我们不会为您展示该条提现记录。",
     "WithdrawInstructionNotificationFailed": "您的提现请求失败，请重试！",
+    "WithdrawHalNotification": "使用HAL收到钱包中的提款通知（您将在那里重定向以进行激活）",
     "LogoutInstruct_1": "退出登录将会清除您浏览器中的账号秘钥。如果忘记了账号秘钥，您可以通过发起以太坊交易设置一个新的账号秘钥。您在交易所的资产不会因为忘记账号秘钥而丢失。",
     "LogoutInstruct_2": "您确定要退出登录吗？",
     "AccountBeingRegisteredInstruct_1": "我们正在为您注册交易账号。这需要您的交易有至少一个区块链确认。请耐心等待！",

--- a/src/modals/WithdrawModal.js
+++ b/src/modals/WithdrawModal.js
@@ -1,4 +1,5 @@
 import { ActionButton, AssetDropdownMenuItem } from "styles/Styles";
+import { Checkbox } from "antd";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -43,6 +44,7 @@ class WithdrawModal extends React.Component {
     amount: null,
     ethBalance: 0,
     ethEnough: true,
+    notifyEnabled: true,
     balance: 0,
     validateAmount: true,
     availableAmount: 0,
@@ -259,6 +261,10 @@ class WithdrawModal extends React.Component {
           this.props.theme,
           15
         );
+
+        if (this.state.notifyEnabled) {
+          window.open(`https://9000.hal.xyz/recipes/loopring-withdrawal-notification?useraddress=${this.props.dexAccount.account.address}`);
+        }
       } catch (err) {
         notifyError(
           <I s="WithdrawInstructionNotificationFailed" />,
@@ -499,6 +505,15 @@ class WithdrawModal extends React.Component {
             >
               <I s="Withdraw" />
             </ActionButton>
+          </Section>
+          <Section>
+            <Checkbox
+              onChange={(e) => {this.setState({ notifyEnabled: e.target.checked })}}
+
+              checked={this.state.notifyEnabled}
+            >
+              <I s="WithdrawHalNotification" />
+            </Checkbox>
           </Section>
         </Spin>
       </MyModal>


### PR DESCRIPTION
This PR introduces the possibility for the user to set up the [withdrawal notification using HAL](https://medium.com/hal-xyz/recipe-4-withdrawals-confirmations-for-loopring-44e7bbe37662)

This is the easiest and less intrusive integration to maintain the DEX privacy-preserving product value but at the same time offer the opportunity for the interested user to use HAL to setup web2 notification.

I've discussed with Matthew about the options and in addition to the one proposed (and agreed), these other ones were discussed:

- Integrate the [GraphQL HAL Api](https://dev.hal.xyz/graphql) to offer a unified experience in Loopring Dex, implementing a UX flow inside the Dex to activate the notification/automation. 
The pro compared to the proposed solution with this PR is in terms of UX, user won't leave the platform and use this feature powered by HAL (whitelabel solution)
The cons are that in terms of privacy it's in contrast with the targeted user of a DEX. Secondly that triggers are created on behalf of the user, so they would be created in the Loopring HAL account. This means that matches aggregates and could generate a billing event for that account instead of being distributed across every user. Third, in term of development, it requires more efforts on both teams

- HAL Widget similar to the [KyberSwap](https://developer.kyber.network/docs/WidgetGenerator/). Stay on the same page but popup a modal and let understand to the user which is using HAL to activate a notification. This would set in the middle with the previous option and the second one in terms of product contrast but let the user have a good UX and avoid the aggregated billing event for Loopring.

I would say that this is the beginning of a path and not an end. If we see users want to have a cleaner and more UX comfy solution we can go ahead and implement the second/third one.

Sorry again @ebirbe for the previous mistake, feel free to comment for additional questions.