### PR TITLE
Fix NaN values on trade orders

### DIFF
--- a/src/pages/trade/open-orders/components/OrderBaseTable.js
+++ b/src/pages/trade/open-orders/components/OrderBaseTable.js
@@ -248,14 +248,18 @@ class OrderBaseTable extends React.Component {
           </LargeTableRow>
         ),
         market: <LargeTableRow>{order.market}</LargeTableRow>,
-        size: <LargeTableRow>{order.sizeInString}</LargeTableRow>,
+        size: (
+          <LargeTableRow>
+            {isNaN(order.sizeInString)? '--': order.sizeInString}
+          </LargeTableRow>
+        ),
         fill_pctg: (
           <LargeTableRow
             style={{
               color: theme.textWhite,
             }}
           >
-            {order.filled}
+            {isNaN(order.filled.substr(0, order.filled.length - 1))? '--' : order.filled}
           </LargeTableRow>
         ),
         price: (
@@ -270,7 +274,7 @@ class OrderBaseTable extends React.Component {
         ),
         total: (
           <LargeTableRow>
-            {order.totalInString} {order.quoteToken}
+            {isNaN(order.totalInString)? '--': `${order.totalInString} ${order.quoteToken}`} 
           </LargeTableRow>
         ),
         date: (


### PR DESCRIPTION
This PR handles UI NaN values while data is being retrieved (by replacing NaN with '--' in order table).

Currently trade orders looks like this while data is loading:
![image](https://user-images.githubusercontent.com/1614749/95739476-32f77e00-0c8b-11eb-9fac-032537bb101f.png)

PR replaces NaN values with the following placeholders:

![image](https://user-images.githubusercontent.com/1614749/95739830-b9ac5b00-0c8b-11eb-8925-9cdffc8f8f7a.png)

Please note: The pre commit eslint hook is throwing errors for me as there doesn't appear to be a linting config file in the repo, so I've had to bypass the lint and commit with --no-verify, however I have tried to follow the existing file formatting.
