### PR TITLE
Add trade pair link to market on order pages

### DIFF
--- a/src/pages/orders/components/HistoryTradesTable.js
+++ b/src/pages/orders/components/HistoryTradesTable.js
@@ -195,7 +195,7 @@ class HistoryTradesTable extends React.Component {
               paddingLeft: "14px",
             }}
           >
-            {order.market}
+            <a href={`../trade/${order.market}`}>{order.market} </a>
           </LargeTableRow>
         ),
         size: (

--- a/src/pages/orders/components/OrderBaseTable.js
+++ b/src/pages/orders/components/OrderBaseTable.js
@@ -246,7 +246,7 @@ class OrderBaseTable extends React.Component {
               paddingLeft: "14px",
             }}
           >
-            {order.market}
+            <a href={`../trade/${order.market}`}>{order.market} </a>
           </LargeTableRow>
         ),
         size: <LargeTableRow>{order.sizeInString} </LargeTableRow>,


### PR DESCRIPTION
This PR converts the plain text market pair on the order pages, into a link that enables user to navigate directly to the relevant market instead of having to click on trades and then select the market from the drop down list.

![image](https://user-images.githubusercontent.com/1614749/95740877-8e2a7000-0c8d-11eb-99eb-5c12090a6df1.png)